### PR TITLE
Make tilakone compatible with clojure 1.8.0

### DIFF
--- a/examples/example/count_ab_example.clj
+++ b/examples/example/count_ab_example.clj
@@ -6,11 +6,11 @@
 (def count-ab-states
   [{::tk/name        :start
     ::tk/transitions [{::tk/on \a, ::tk/to :found-a}
-                      {::tk/on _}]}
+                      {::tk/on ::tk/_}]}
    {::tk/name        :found-a
     ::tk/transitions [{::tk/on \a}
                       {::tk/on \b, ::tk/to :start, ::tk/actions [:inc-val]}
-                      {::tk/on _, ::tk/to :start}]}])
+                      {::tk/on ::tk/_, ::tk/to :start}]}])
 
 ; FSM has states, a function to execute actions, and current state and value:
 

--- a/modules/core/project.clj
+++ b/modules/core/project.clj
@@ -1,7 +1,7 @@
-(defproject metosin/tilakone.core "0.0.4"
+(defproject helpshift/tilakone.core "0.0.5-SNAPSHOT"
   :description "Minimal finite state machine library"
-  :url "https://github.com/metosin/tilakone"
-  :scm {:name "git", :url "https://github.com/metosin/tilakone"}
+  :url "https://github.com/helpshift/tilakone"
+  :scm {:name "git", :url "https://github.com/helpshift/tilakone"}
   :dependencies []
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"})

--- a/modules/graph/project.clj
+++ b/modules/graph/project.clj
@@ -1,6 +1,6 @@
-(defproject metosin/tilakone.graph "0.0.0-SNAPSHOT"
+(defproject helpshift/tilakone.graph "0.0.1-SNAPSHOT"
   :description "Minimal finite state machine library"
-  :dependencies [[metosin/tilakone.core "0.0.0-SNAPSHOT"]
+  :dependencies [[helpshift/tilakone.core "0.0.5-SNAPSHOT"]
                  [dorothy "0.0.7"]]
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"})

--- a/modules/schema/project.clj
+++ b/modules/schema/project.clj
@@ -1,8 +1,8 @@
-(defproject metosin/tilakone.schema "0.0.4"
+(defproject helpshift/tilakone.schema "0.0.5-SNAPSHOT"
   :description "Minimal finite state machine library"
-  :url "https://github.com/metosin/tilakone"
-  :scm {:name "git", :url "https://github.com/metosin/tilakone"}
-  :dependencies [[metosin/tilakone.core "0.0.4"]
+  :url "https://github.com/helpshift/tilakone"
+  :scm {:name "git", :url "https://github.com/helpshift/tilakone"}
+  :dependencies [[helpshift/tilakone.core "0.0.5-SNAPSHOT"]
                  [prismatic/schema "1.1.9"]]
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"})

--- a/modules/schema/src/tilakone/schema.clj
+++ b/modules/schema/src/tilakone/schema.clj
@@ -49,7 +49,7 @@
         errors       (mapcat (fn [state]
                                (->> state
                                     ::tk/transitions
-                                    (remove (fn [{::tk/keys [to]}]
+                                    (remove (fn [{:keys [::tk/to]}]
                                               (or (nil? to)
                                                   (known-state? to))))
                                     (map (fn [transition]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject metosin/tilakone.root "0.0.0"
+(defproject helpshift/tilakone.root "0.0.1-SNAPSHOT"
   :description "Minimal finite state machine library"
   :dependencies []
   :source-paths ["dev"
@@ -9,7 +9,7 @@
   :test-paths ["modules/core/test"
                "modules/schema/test"
                "modules/graph/test"]
-  :profiles {:dev  {:dependencies [[org.clojure/clojure "1.10.0"]
+  :profiles {:dev  {:dependencies [[org.clojure/clojure "1.8.0"]
                                    ; Dev workflow:
                                    [org.clojure/tools.namespace "0.2.11"]
                                    ; Module deps:


### PR DESCRIPTION
+ Master of tilakone is compatible with clojure 1.10.0. Make it
  compatible with clojure 1.8.0
+ Improve code indentation
+ Remove use of qualified-keywords
+ Update examples